### PR TITLE
Autodetects Buzz device

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-buzzers",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "src/index.js",
   "scripts": {
     "dev": "node examples/simple",

--- a/src/device.js
+++ b/src/device.js
@@ -1,8 +1,7 @@
 module.exports = (nodeHid, mapDeviceDataToPressedButtons) => {
-    const VENDOR_ID = '1356';
-    const PRODUCT_ID = '4096';
 
-    const device = new nodeHid.HID(VENDOR_ID, PRODUCT_ID);
+    const buzzDevice = nodeHid.devices().find(device => device.product.match(/Buzz/));
+    const device = new nodeHid.HID(buzzDevice.vendorId, buzzDevice.productId);
 
     return {
         setLeds(states) {


### PR DESCRIPTION
The library was unable to find my PS2 (wired) buzzers on my Macbook. 

It turned out it used the wrong productId. I suspect the productId is variable.
I therefor created a fork which autodetects the Buzz buttons based on the product name.