### PR TITLE
Autodetect buzz device

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ Then release the button and press it once more. Now you can start your node prog
 
 ## Changelog
 
+### 1.0.3
+- Some buzzer devices seem to use a different vendorId/productId and connecting the buzzers failed. Now `buzz-buzzers` is additionally searching for the name `Buzz` of connected usb devices if a device with could not be found by vendorId/productId. See: https://github.com/functino/buzz-buzzers/pull/3
+
+- Update of all dependencies
+
 ### 1.0.2
 Update of all dependencies.
 

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   },
   "author": "Andreas",
   "dependencies": {
-    "node-hid": "0.7.3"
+    "node-hid": "0.7.6"
   },
   "devDependencies": {
-    "ava": "0.25.0",
-    "eslint": "5.6.1",
-    "prettier": "1.14.3",
-    "sinon": "6.3.5"
+    "ava": "1.0.1",
+    "eslint": "5.12.0",
+    "prettier": "1.15.3",
+    "sinon": "7.2.2"
   },
   "description": "Simple access to buzz buzzers",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "buzz-buzzers",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "main": "src/index.js",
   "scripts": {
     "dev": "node examples/simple",

--- a/src/connectDevice.js
+++ b/src/connectDevice.js
@@ -1,0 +1,13 @@
+function findDeviceByName(nodeHid) {
+    const buzzDevice = nodeHid.devices().find(d => d.product.match(/Buzz/));
+    return new nodeHid.HID(buzzDevice.vendorId, buzzDevice.productId);
+}
+module.exports = function(nodeHid) {
+    const VENDOR_ID = '1356';
+    const PRODUCT_ID = '4096';
+    try {
+        return new nodeHid.HID(VENDOR_ID, PRODUCT_ID);
+    } catch (e) {
+        return findDeviceByName(nodeHid);
+    }
+};

--- a/src/device.js
+++ b/src/device.js
@@ -1,8 +1,7 @@
 module.exports = (nodeHid, mapDeviceDataToPressedButtons) => {
-    const VENDOR_ID = '1356';
-    const PRODUCT_ID = '4096';
 
-    const device = new nodeHid.HID(VENDOR_ID, PRODUCT_ID);
+    const buzzDevice = nodeHid.devices().find(device => device.product.match(/Buzz/));
+    const device = new nodeHid.HID(buzzDevice.vendorId, buzzDevice.productId);
 
     return {
         setLeds(states) {

--- a/src/device.js
+++ b/src/device.js
@@ -1,8 +1,7 @@
-module.exports = (nodeHid, mapDeviceDataToPressedButtons) => {
+const nodeHid = require('node-hid');
 
-    const buzzDevice = nodeHid.devices().find(device => device.product.match(/Buzz/));
-    const device = new nodeHid.HID(buzzDevice.vendorId, buzzDevice.productId);
-
+module.exports = (connectDevice, mapDeviceDataToPressedButtons) => {
+    const device = connectDevice(nodeHid);
     return {
         setLeds(states) {
             device.write(

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,9 @@
 const buzzer = require('./buzzer');
 const device = require('./device');
-const nodeHid = require('node-hid');
+const connectDevice = require('./connectDevice');
 const readBytes = require('./parser/readBytes');
 const mapDeviceDataToPressedButtons = require('./parser/mapDeviceDataToPressedButtons')(
     readBytes
 );
 
-module.exports = () => buzzer(device(nodeHid, mapDeviceDataToPressedButtons));
+module.exports = () => buzzer(device(connectDevice, mapDeviceDataToPressedButtons));

--- a/test/connectDeviceSpec.js
+++ b/test/connectDeviceSpec.js
@@ -1,0 +1,32 @@
+const test = require('ava');
+const sinon = require('sinon');
+const connectDevice = require('../src/connectDevice');
+const usbDevice = {};
+
+test('connectDevice with vendorId and productId', t => {
+    const nodeHid = {
+        HID: sinon.stub().returns(usbDevice)
+    };
+    const device = connectDevice(nodeHid);
+    t.is(device, usbDevice);
+});
+
+test('connectDevice by name after vendorId and productId attempt failed', t => {
+    const nodeHid = {
+        HID: sinon.stub(),
+        devices: sinon.stub().returns([
+            {
+                product: 'foo'
+            },
+            {
+                product: 'Sony Buzz! Wireless',
+                vendorId: 1,
+                productId: 2
+            }
+        ])
+    };
+    nodeHid.HID.onFirstCall().throws('device not found');
+    nodeHid.HID.withArgs(1, 2).returns(usbDevice);
+    const device = connectDevice(nodeHid);
+    t.is(device, usbDevice);
+});

--- a/test/deviceSpec.js
+++ b/test/deviceSpec.js
@@ -1,16 +1,19 @@
 const test = require('ava');
 const sinon = require('sinon');
+const nodeHid = require('node-hid');
 
 const mapDeviceDataToPressedButtons = sinon.stub();
 const usbDevice = {
     write: sinon.stub(),
     on: sinon.stub()
 };
-const nodeHid = {
-    HID: sinon.stub().returns(usbDevice)
-};
+const connectDevice = sinon.stub().returns(usbDevice);
 
-const device = require('../src/device')(nodeHid, mapDeviceDataToPressedButtons);
+const device = require('../src/device')(connectDevice, mapDeviceDataToPressedButtons);
+
+test('use connectDevice to connect to device', t => {
+    t.true(connectDevice.calledWith(nodeHid));
+});
 
 test('setLeds to switch off all leds ', t => {
     device.setLeds([false, false, false, false]);


### PR DESCRIPTION
Some devices seem not to use the vendorId/productId that I hardcoded. To make connecting buzzers more fail-safe we now also search by name as a fallback.

See also: https://github.com/functino/buzz-buzzers/pull/3

