### PR TITLE
move to a ^ so that we upgrade to new versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "author": "Andreas",
   "dependencies": {
-    "node-hid": "0.7.6"
+    "node-hid": "^0.7.9"
   },
   "devDependencies": {
     "ava": "1.0.1",


### PR DESCRIPTION
0.7.7 I think added back in a pre built version for use in electron. the hard coded 0.7.6 was stopping yarn or npm installing the latest version